### PR TITLE
1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acpr/rate-limit-postgresql",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acpr/rate-limit-postgresql",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@types/pg-pool": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acpr/rate-limit-postgresql",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A PostgreSQL store for the `express-rate-limit` middleware",
   "homepage": "https://github.com/adrianprelipcean/express-rate-limit-postgresql",
   "repository": "https://github.com/adrianprelipcean/express-rate-limit-postgresql",

--- a/third_party_licenses/dev_detailed.json
+++ b/third_party_licenses/dev_detailed.json
@@ -1,5 +1,5 @@
 {
-    "@acpr/rate-limit-postgresql@1.3.1": {
+    "@acpr/rate-limit-postgresql@1.3.2": {
         "licenses": "MIT",
         "repository": "https://github.com/adrianprelipcean/express-rate-limit-postgresql",
         "publisher": "Adrian C. Prelipcean"

--- a/third_party_licenses/production_detailed.json
+++ b/third_party_licenses/production_detailed.json
@@ -1,5 +1,5 @@
 {
-    "@acpr/rate-limit-postgresql@1.3.1": {
+    "@acpr/rate-limit-postgresql@1.3.2": {
         "licenses": "MIT",
         "repository": "https://github.com/adrianprelipcean/express-rate-limit-postgresql",
         "publisher": "Adrian C. Prelipcean"


### PR DESCRIPTION
The package patch was missing from the [previous PR](https://github.com/express-rate-limit/rate-limit-postgresql/pull/10) 