### PR TITLE
meta: updated URLs from personal to organization

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -134,4 +134,4 @@ jobs:
           files: acpr-rate-limit-postgresql.tgz
           body:
             You can view the changelog
-            [here](https://github.com/adrianprelipcean/express-rate-limit-postgresql/blob/master/changelog.md).
+            [here](https://github.com/express-rate-limit/express-rate-limit-postgresql/blob/master/changelog.md).

--- a/changelog.md
+++ b/changelog.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.2](https://github.com/adrianprelipcean/express-rate-limit-postgresql/releases/tag/v1.3.2)
+## [1.3.2](https://github.com/express-rate-limit/express-rate-limit-postgresql/releases/tag/v1.3.2)
 
 ### Added
 
 - Enabled provenance statement generation, see
   https://github.com/express-rate-limit/express-rate-limit#406.
 
-## [1.3.1](https://github.com/adrianprelipcean/express-rate-limit-postgresql/releases/tag/v1.3.1)
+## [1.3.1](https://github.com/express-rate-limit/express-rate-limit-postgresql/releases/tag/v1.3.1)
 
 ### Changed
 
@@ -22,32 +22,32 @@ and this project adheres to
   and
   [sqlfluff](https://github.com/express-rate-limit/rate-limit-postgresql/security/dependabot/2)
 
-## [1.3.0](https://github.com/adrianprelipcean/express-rate-limit-postgresql/releases/tag/v1.3.0)
+## [1.3.0](https://github.com/express-rate-limit/express-rate-limit-postgresql/releases/tag/v1.3.0)
 
 ### Changed
 
 - Stores call stored procedures instead of raw SQL
 
-## [1.2.0](https://github.com/adrianprelipcean/express-rate-limit-postgresql/releases/tag/v1.2.0)
+## [1.2.0](https://github.com/express-rate-limit/express-rate-limit-postgresql/releases/tag/v1.2.0)
 
 ### Changed
 
 - `express-rate-limit` moved from `dependencies` to `peerDependencies`
 
-## [1.1.1](https://github.com/adrianprelipcean/express-rate-limit-postgresql/releases/tag/v1.1.1)
+## [1.1.1](https://github.com/express-rate-limit/express-rate-limit-postgresql/releases/tag/v1.1.1)
 
 ### Added
 
 - Refactored `name` to `prefix` according the
   [express-rate-limit@6.11.1](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v6.11.1)
 
-## [1.1.0](https://github.com/adrianprelipcean/express-rate-limit-postgresql/releases/tag/v1.1.0)
+## [1.1.0](https://github.com/express-rate-limit/express-rate-limit-postgresql/releases/tag/v1.1.0)
 
 ### Added
 
 - Using [pkgroll](https://github.com/privatenumber/pkgroll) to bundle library
 
-## [1.0.2](https://github.com/adrianprelipcean/express-rate-limit-postgresql/releases/tag/v1.0.2)
+## [1.0.2](https://github.com/express-rate-limit/express-rate-limit-postgresql/releases/tag/v1.0.2)
 
 ### Added
 

--- a/contributing.md
+++ b/contributing.md
@@ -26,7 +26,7 @@ and [`clone`](https://github.com/git-guides/git-clone) the repository
 (`adrianprelipcean/express-rate-limit-postgresql`).
 
 Once you have forked and cloned the repository, you can
-[pick out an issue](https://github.com/adrianprelipcean/express-rate-limit-postgresql/issues)
+[pick out an issue](https://github.com/express-rate-limit/express-rate-limit-postgresql/issues)
 you want to fix/implement!
 
 ## Making Changes

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@acpr/rate-limit-postgresql",
   "version": "1.3.2",
   "description": "A PostgreSQL store for the `express-rate-limit` middleware",
-  "homepage": "https://github.com/adrianprelipcean/express-rate-limit-postgresql",
-  "repository": "https://github.com/adrianprelipcean/express-rate-limit-postgresql",
+  "homepage": "https://github.com/express-rate-limit/rate-limit-postgresql",
+  "repository": "https://github.com/express-rate-limit/rate-limit-postgresql",
   "author": {
     "name": "Adrian C. Prelipcean"
   },

--- a/third_party_licenses/dev_detailed.json
+++ b/third_party_licenses/dev_detailed.json
@@ -1,7 +1,7 @@
 {
     "@acpr/rate-limit-postgresql@1.3.2": {
         "licenses": "MIT",
-        "repository": "https://github.com/adrianprelipcean/express-rate-limit-postgresql",
+        "repository": "https://github.com/express-rate-limit/rate-limit-postgresql",
         "publisher": "Adrian C. Prelipcean"
     },
     "@cspotcode/source-map-support@0.8.1": {

--- a/third_party_licenses/production_detailed.json
+++ b/third_party_licenses/production_detailed.json
@@ -1,7 +1,7 @@
 {
     "@acpr/rate-limit-postgresql@1.3.2": {
         "licenses": "MIT",
-        "repository": "https://github.com/adrianprelipcean/express-rate-limit-postgresql",
+        "repository": "https://github.com/express-rate-limit/rate-limit-postgresql",
         "publisher": "Adrian C. Prelipcean"
     },
     "@types/node@20.6.3": {


### PR DESCRIPTION
I needed to change the URLs throughout the repository to allow for the provenance flag - see [failing pipeline](https://github.com/express-rate-limit/rate-limit-postgresql/actions/runs/6467058923/job/17556420345)