### PR TITLE
handle migration failure gracefully

### DIFF
--- a/source/util/migration_handler.ts
+++ b/source/util/migration_handler.ts
@@ -8,5 +8,9 @@ export async function applyMigrations(config: any): Promise<void> {
 		host: config['host'] || 'localhost',
 		port: config['port'] || 5432,
 	}
-	await migrate(dbConfig, __dirname + '/migrations')
+	try{
+		await migrate(dbConfig, __dirname + '/migrations')
+	}catch(err){
+		console.error(err); //if we are using typeorm and handling migration in base project, handle the exception
+	}
 }


### PR DESCRIPTION
Migration was failing if we use typeorm, so handled it gracefully and migration I am now handling it in by base project

```
Error: Migration failed. Reason: Hashes don't match for migrations '0_create-migrations-table.sql,1-init.sql,2-add-db-functions-agg.sql,3-add-db-functions-ind.sql,4-add-db-functions-sessions.sql,5-hotfix-update-constraints.sql'.
This means that the scripts have changed since it was applied.
    at C:\Users\shnat\Desktop\atoa3\ATOACore\node_modules\postgres-migrations\dist\migrate.js:100:27
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at C:\Users\shnat\Desktop\atoa3\ATOACore\node_modules\postgres-migrations\dist\with-lock.js:25:28
    at C:\Users\shnat\Desktop\atoa3\ATOACore\node_modules\postgres-migrations\dist\with-connection.js:16:28
    at applyMigrations (C:\Users\shnat\Desktop\atoa3\ATOACore\node_modules\@acpr\rate-limit-postgresql\dist\index.cjs:78:3)
[ERROR] 13:44:52 Error: Migration failed. Reason: Hashes don't match for migrations '0_create-migrations-table.sql,1-init.sql,2-add-db-functions-agg.sql,3-add-db-functions-ind.sql,4-add-db-functions-sessions.sql,5-hotfix-update-constraints.sql'.
```

This means that the scripts have changed since it was applied.

Fixes #13 (sort of)