### PR TITLE
Test on node.js version 16.x, lts/*, and latest

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, lts/*, latest]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
This will run the tests on the current stable and LTS releases of node.js (v20 and v21 at the moment) + v16 to prevent backwards-incompatible changes.