### PR TITLE
fix: Support standard node-postgres config for migration

### DIFF
--- a/source/util/migration_handler.ts
+++ b/source/util/migration_handler.ts
@@ -1,7 +1,12 @@
-import { Pool } from 'pg'
+import { Client } from 'pg'
 import { migrate } from 'postgres-migrations'
 
 export async function applyMigrations(config: any): Promise<void> {
-	const pool = new Pool(config)
-	await migrate({ client: pool }, __dirname + '/migrations')
+	const client = new Client(config)
+	await client.connect()
+	try {
+		await migrate({ client }, __dirname + '/migrations')
+	} finally {
+		await client.end()
+	}
 }

--- a/source/util/migration_handler.ts
+++ b/source/util/migration_handler.ts
@@ -1,8 +1,8 @@
-import { Client } from 'pg'
+import pg from 'pg'
 import { migrate } from 'postgres-migrations'
 
 export async function applyMigrations(config: any): Promise<void> {
-	const client = new Client(config)
+	const client = new pg.Client(config)
 	await client.connect()
 	try {
 		await migrate({ client }, __dirname + '/migrations')

--- a/source/util/migration_handler.ts
+++ b/source/util/migration_handler.ts
@@ -1,12 +1,7 @@
+import { Pool } from 'pg'
 import { migrate } from 'postgres-migrations'
 
 export async function applyMigrations(config: any): Promise<void> {
-	const dbConfig = {
-		database: config['database'] || 'postgres',
-		user: config['user'] || 'postgres',
-		password: config['password'] || 'postgres',
-		host: config['host'] || 'localhost',
-		port: config['port'] || 5432,
-	}
-	await migrate(dbConfig, __dirname + '/migrations')
+	const pool = new Pool(config)
+	await migrate({ client: pool }, __dirname + '/migrations')
 }


### PR DESCRIPTION
Hello 👋

I recently ran into an issue when running this in my prod env where the migration is unable to properly run. In my configuration, my database is hosted elsewhere and requires an SSL connection. Although the docs say...

> `config` - The database configuration as specified in the [node-postgres](https://node-postgres.com/apis/client) configuration.

It is not entirely true when running migrations. Looking at the  code, the `applyMigrations` function only sets a subset of the options https://github.com/express-rate-limit/rate-limit-postgresql/blob/e29c77383e981cb1f5caf8a49a65b71549cd4bff/source/util/migration_handler.ts#L5-L9

The proposed solution I have is to instantiate a pg `Pool` with the given config and pass it along to `postgres-migrations`. This is also how the standard code path creates a connection to the database, making for a more consistent experience as well.